### PR TITLE
Fix: Update empty state text in latest updates section

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -600,14 +600,18 @@ export function PostList({
     return (
       <div className="p-8 text-center border border-border/30 rounded-md bg-card">
         <p className="text-muted-foreground mb-2">
-          {showOnlyApproved
+          {showOnlyApproved && showOnlyOwnerAndModerators && showOnlyAnnouncements
+            ? "Nothing new yet."
+            : showOnlyApproved
             ? "No approved posts in this group yet"
             : pendingOnly
             ? "No pending posts in this group"
             : "No posts in this group yet"}
         </p>
         <p className="text-sm">
-          {showOnlyApproved && pendingCount > 0
+          {showOnlyApproved && showOnlyOwnerAndModerators && showOnlyAnnouncements
+            ? ""
+            : showOnlyApproved && pendingCount > 0
             ? `There are ${pendingCount} pending posts waiting for approval.`
             : pendingOnly
             ? "All posts have been approved or removed."


### PR DESCRIPTION
## Summary
- Updates the empty state text in the latest updates section from "No approved post in this group yet be the first to post something" to "Nothing new yet."
- The change specifically targets the PostList component when used with the exact filters applied in the latest updates section (approved announcements from owners/moderators)

## Test plan
- [x] Navigate to a group detail page
- [x] Go to the home tab  
- [x] Verify the latest updates section shows "Nothing new yet." when no announcements are present
- [x] Confirm other uses of PostList component are unaffected
- [x] TypeScript compilation passes

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the empty state text in the latest updates section to handle different combinations of filters, including approved, owner and moderators, and announcements filters.

### Why are these changes being made?
These changes are being made to enhance the user experience by providing clear and specific messages in the PostList component when there are no posts to display, based on applied filters. This approach improves clarity and accurately reflects the state of the posts, ensuring users have a better understanding of the content availability in various scenarios.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->